### PR TITLE
[RDY] Support for öäü characters, Labelpositions in milimeters, some more zpl features

### DIFF
--- a/src/FluentZpl/PrinterConnection.cs
+++ b/src/FluentZpl/PrinterConnection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using ZplLabels.Common.Extensions;
+using System.Linq;
 
 namespace ZplLabels
 {
@@ -14,38 +15,44 @@ namespace ZplLabels
 
     /// <summary>
     /// Summary description for PrinterConnectionConnection.
-	/// </summary>
-	public class PrinterConnection : IPrinterConnection
+    /// </summary>
+    public class PrinterConnection : IPrinterConnection
     {
         private const int Port = 9100;  //for ZEBRA PRINTERs
 
-        private const int TimeOut = 30; 
- 
+        private const int TimeOut = 30;
 
- 
+        public string Print(string scriptStr, string printerName)
+        {
+            IPHostEntry ipHostInfo = Dns.GetHostEntry(printerName);
+            IPAddress ipAddress = ipHostInfo.AddressList
+                .FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
+
+            return Print(scriptStr, ipAddress);
+        }
+
         public string Print(string scriptStr, IPAddress ipAddress)
-		{  
+        {
 
-			try
-			{
-			    byte[] buff = scriptStr.ToByteArray();
+            try
+            {
+                byte[] buff = scriptStr.ToByteArray();
 
                 using (var tcp = new TcpClient(ipAddress.ToString(), Port) { ReceiveTimeout = TimeOut })
                 using (var stream = tcp.GetStream())
                 {
                     stream.Write(buff, 0, buff.Length);
-			    }
-                
-		        return "OK";
-			}
-			catch (Exception e)
-			{
-                Logger.Error(this,"Error Printing Label",e);
-				string msg = e.Message;
-				return msg;
-			}
-		}
+                }
+
+                return "OK";
+            }
+            catch (Exception e)
+            {
+                Logger.Error(this, "Error Printing Label", e);
+                string msg = e.Message;
+                return msg;
+            }
+        }
 
     }
 }
-

--- a/src/FluentZpl/Utilities/DPIHelper.cs
+++ b/src/FluentZpl/Utilities/DPIHelper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ZplLabels.Utilities
+{
+    /// <summary>
+    /// Converts Pixel to mm and mm to Pixel
+    /// Requires DPI-Value from Printer
+    /// </summary>
+    public class DPIHelper
+    {
+
+        public DPIHelper(int dpi)
+        {
+            this.dpi = dpi;
+        }
+
+        public int dpi { get; set; }
+        public double dpmm { get { return dpi / 25.4; } }
+
+
+        /// <summary>
+        /// converts distance from milimeter to Pixel
+        /// </summary>
+        /// <param name="mm">Distance in mm</param>
+        /// <returns>Pixels</returns>
+        public int mmToPx(int mm)
+        {
+            return (int)Math.Round(mm * dpmm);
+        }
+
+        /// <summary>
+        /// converts distance from milimeter to Pixel
+        /// </summary>
+        /// <param name="mm">Distance in mm</param>
+        /// <returns>Pixels</returns>
+        public int mmToPx(double mm)
+        {
+            return (int)Math.Round(mm * dpmm);
+        }
+
+        /// <summary>
+        /// converts Pixel to milimeters
+        /// </summary>
+        /// <param name="px">Pixel</param>
+        /// <returns>Distance in mm</returns>
+        public double pxTomm(int px)
+        {
+            return px / dpmm;
+        }
+
+        /// <summary>
+        /// converts dots to dotrows 
+        /// some zpl commands require dotrows as parameter
+        /// </summary>
+        /// <param name="dots"></param>
+        /// <returns></returns>
+        public int dotsToDotRows(int dots)
+        {
+            return (int)Math.Round(dots / 2.0);
+        }
+    }
+}

--- a/src/FluentZpl/ZPL/FieldBlock.cs
+++ b/src/FluentZpl/ZPL/FieldBlock.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace ZplLabels.ZPL
+﻿namespace ZplLabels.ZPL
 {
     public class FieldBlock 
     {

--- a/src/FluentZpl/ZPL/FieldData.cs
+++ b/src/FluentZpl/ZPL/FieldData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace ZplLabels.ZPL
+﻿namespace ZplLabels.ZPL
 {
     public class FieldData
     {
@@ -17,6 +15,17 @@ namespace ZplLabels.ZPL
 
         public override string ToString()
         {
+            if (_data.Contains("ä") || _data.Contains("ö") || _data.Contains("ü") || _data.Contains("Ö") ||
+                _data.Contains("Ä") || _data.Contains("Ü"))
+            {
+                _data = _data.Replace("ä", "_84")
+               .Replace("ö", "_94")
+               .Replace("ü", "_81")
+               .Replace("Ä", "_8E")
+               .Replace("Ö", "_99")
+               .Replace("Ü", "_9A");
+                return string.Format("^FH^FD{0}^FS\r\n", _data);
+            }
             return string.Format("^FD{0}^FS\r\n", _data);
         }
     }

--- a/src/FluentZpl/ZPL/FieldGenerator.cs
+++ b/src/FluentZpl/ZPL/FieldGenerator.cs
@@ -7,5 +7,43 @@
         protected FieldData _data;
         protected FieldBlock _block;
         protected string _script = "";
+
+        public IFieldGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double fromLeft, double fromTop)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(fromLeft), dpiHelper.mmToPx(fromTop));
+            return this;
+        }
+
+        public IFieldGenerator At(int fromLeft, int fromTop)
+        {
+            _position = new LabelPosition(fromLeft, fromTop);
+            return this;
+        }
+
+        public IFieldGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double fromLeft, double fromTop,
+            LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(fromLeft), dpiHelper.mmToPx(fromTop), alignment);
+            return this;
+        }
+
+        public IFieldGenerator At(int fromLeft, int fromTop, LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(fromLeft, fromTop, alignment);
+            return this;
+        }
+
+        public IFieldGenerator Move(int fromLeft, int fromTop)
+        {
+            _position = new LabelPosition(_position.X + fromLeft, _position.Y + fromTop, _position.Alignment);
+            return this;
+        }
+
+        public IFieldGenerator Move(ZplLabels.Utilities.DPIHelper dpiHelper, double fromLeft, double fromTop)
+        {
+            _position = new LabelPosition(_position.X + dpiHelper.mmToPx(fromLeft), _position.Y + dpiHelper.mmToPx(fromTop),
+                _position.Alignment);
+            return this;
+        }
     }
 }

--- a/src/FluentZpl/ZPL/GraphicBoxGenerator.cs
+++ b/src/FluentZpl/ZPL/GraphicBoxGenerator.cs
@@ -10,9 +10,55 @@
         {
             return string.Format("{0}^GB{1},{2},{3},{4}^FS\r\n", _position, _width, _height, _lineThickness, _color);
         }
+
+        /// <summary>
+        /// Set Graphic Box position in pixel
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
         public GraphicBoxGenerator At(int x, int y)
         {
             _position = new LabelPosition(x, y);
+            return this;
+        }
+
+        /// <summary>
+        /// Set Graphic Box position in milimeter
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public GraphicBoxGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double x, double y)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(x), dpiHelper.mmToPx(y));
+            return this;
+        }
+
+        /// <summary>
+        /// Set Graphic Box position in pixel
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public GraphicBoxGenerator At(int x, int y, LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(x, y, alignment);
+            return this;
+        }
+
+        /// <summary>
+        /// Set Graphic Box position in milimeter
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public GraphicBoxGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double x, double y,
+            LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(x), dpiHelper.mmToPx(y), alignment);
             return this;
         }
 

--- a/src/FluentZpl/ZPL/IFieldGenerator.cs
+++ b/src/FluentZpl/ZPL/IFieldGenerator.cs
@@ -3,5 +3,11 @@
     public interface IFieldGenerator
     {
         string ToString();
+        IFieldGenerator At(int x, int y);
+        IFieldGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double x, double y);
+        IFieldGenerator At(int x, int y, LabelPosition.LabelAlignemnet alignment);
+        IFieldGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double x, double y, LabelPosition.LabelAlignemnet alignment);
+        IFieldGenerator Move(int x, int y);
+        IFieldGenerator Move(ZplLabels.Utilities.DPIHelper dpiHelper, double x, double y);
     }
 }

--- a/src/FluentZpl/ZPL/LabelBarcodeGenerator.cs
+++ b/src/FluentZpl/ZPL/LabelBarcodeGenerator.cs
@@ -5,15 +5,17 @@ namespace ZplLabels.ZPL
     using ZplLabels.ZPL;
 
     public class LabelBarcodeGenerator : FieldGenerator
-    { 
+    {
         private BarcodeType _barcodeType = BarcodeType.Code128;
-        private   FieldOrientation _orientation = FieldOrientation.Normal;
+        private FieldOrientation _orientation = FieldOrientation.Normal;
         private FontDefinition _font;
         private BarWidth _width = new BarWidth(3);
         private int _height;
         private int _totalDots;
+        private bool _barcodeTextLabel = false;
+        private bool _upperASCIIChar = false;
 
-        public   LabelBarcodeGenerator SetBarcodeType(BarcodeType type)
+        public LabelBarcodeGenerator SetBarcodeType(BarcodeType type)
         {
             _barcodeType = type;
             return this;
@@ -25,9 +27,54 @@ namespace ZplLabels.ZPL
             return this;
         }
 
+        /// <summary>
+        /// Set Barcode position in pixel
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
         public LabelBarcodeGenerator At(int x, int y)
-        { 
+        {
             _position = new LabelPosition(x, y);
+            return this;
+        }
+
+        /// <summary>
+        /// Set Barcode Position in milimeter
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public LabelBarcodeGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double x, double y)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(x), dpiHelper.mmToPx(y));
+            return this;
+        }
+
+        /// <summary>
+        /// Set Barcode position in pixel
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public LabelBarcodeGenerator At(int x, int y, LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(x, y, alignment);
+            return this;
+        }
+
+        /// <summary>
+        /// Set Barcode Position in milimeter
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        public LabelBarcodeGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double x, double y,
+            LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(x), dpiHelper.mmToPx(y), alignment);
             return this;
         }
 
@@ -51,6 +98,10 @@ namespace ZplLabels.ZPL
         }
         public LabelBarcodeGenerator WithData(string value)
         {
+            if (value.Contains("ä") || value.Contains("ö") || value.Contains("ü") || value.Contains("Ö") || value.Contains("Ä") || value.Contains("Ü"))
+            {
+                _upperASCIIChar = true;
+            }
             _data = new FieldData(value);
             return this;
         }
@@ -62,26 +113,36 @@ namespace ZplLabels.ZPL
             return this;
         }
 
+        public LabelBarcodeGenerator printTextLabel(bool barcodeTextLabel)
+        {
+            _barcodeTextLabel = barcodeTextLabel;
+            return this;
+        }
+
         public override string ToString()
-        { 
+        {
             if (_position == null) throw new ApplicationException("Field position must be set for barcode generator");
             if (_data == null) throw new ApplicationException("Field data must be set for barcode generator");
             var barcodePosition = getBarcodePosition();
             var textPosition = new LabelPosition(_position.X, _position.Y + getHeights());
-            return barcodePosition +   _barcodeType.Value + paramList() + _width +  _data + textPosition + getBlock() + getFont() + _data;
+            if (_barcodeTextLabel == true)
+            {
+                return barcodePosition + _barcodeType.Value + paramList() + _width + _data + textPosition + getBlock() + getFont() + _data;
+            }
+            return barcodePosition + _barcodeType.Value + paramList() + _width + _data;
         }
 
         private LabelPosition getBarcodePosition()
         {
             if (_totalDots == 0) return _position;
-            var x = _totalDots/2;
-            var barWidth =getBarWidthPerCharacter()*2 + getBarWidthPerCharacter()*_data.Length + getBarWidthPerCharacter()*2 + 2;
-            return new LabelPosition(x - barWidth/2, _position.Y);
+            var x = _totalDots / 2;
+            var barWidth = getBarWidthPerCharacter() * 2 + getBarWidthPerCharacter() * _data.Length + getBarWidthPerCharacter() * 2 + 2;
+            return new LabelPosition(x - barWidth / 2, _position.Y);
         }
 
         private int getBarWidthPerCharacter()
         {
-            return _width.Value*11;
+            return _width.Value * 11;
         }
         private int getHeights()
         {
@@ -93,19 +154,19 @@ namespace ZplLabels.ZPL
 
         private string getFont()
         {
-            if (_font == null) return ""; 
-//            var maxLength = LABELWIDTH / _font.Width - (((LABELWIDTH / _font.Width) / 2) -1);
-//            if(maxLength < _data.Length)
-//            {
-//                _font = getAdjustedFont(_data.Length, LABELWIDTH, _font.FontType);
-//            }
+            if (_font == null) return "";
+            //            var maxLength = LABELWIDTH / _font.Width - (((LABELWIDTH / _font.Width) / 2) -1);
+            //            if(maxLength < _data.Length)
+            //            {
+            //                _font = getAdjustedFont(_data.Length, LABELWIDTH, _font.FontType);
+            //            }
 
             return _font.ToString();
         }
 
         private static FontDefinition getAdjustedFont(int length, int totalWidth, string fontType)
         {
-            var fontSize = (int) (length*1.8/totalWidth);
+            var fontSize = (int)(length * 1.8 / totalWidth);
             return new FontDefinition(fontType, fontSize);
         }
 
@@ -117,7 +178,11 @@ namespace ZplLabels.ZPL
 
         private string paramList()
         {
-            return _orientation.Value + "," + _height + ",N,N,N,N\r\n";
+            if (_upperASCIIChar == true)
+            {
+                return _orientation.Value + "," + _height + ",200,N,N,6\r\n";
+            }
+            return _orientation.Value + "," + _height + ",200,N,N,3\r\n";
         }
     }
 }

--- a/src/FluentZpl/ZPL/LabelPosition.cs
+++ b/src/FluentZpl/ZPL/LabelPosition.cs
@@ -1,17 +1,43 @@
-﻿namespace ZplLabels.ZPL
+﻿using System;
+
+namespace ZplLabels.ZPL
 {
-    public class LabelPosition
+    public class LabelPosition : ICloneable
     {
+        public enum LabelAlignemnet
+        {
+            left, right
+        }
+
         public LabelPosition(int xAxis, int yAxis)
         {
             X = xAxis;
             Y = yAxis;
+            Alignment = LabelAlignemnet.left;
         }
+
+        public LabelPosition(int xAxis, int yAxis, LabelAlignemnet alignment)
+        {
+            X = xAxis;
+            Y = yAxis;
+            Alignment = alignment;
+        }
+
         public int X { get; private set; }
         public int Y { get; private set; }
-        public override string  ToString()
+        public LabelAlignemnet Alignment { get; private set; }
+        public override string ToString()
         {
+            if (Alignment == LabelAlignemnet.right)
+            {
+                return string.Format("^FO{0},{1},1", X, Y);
+            }
             return string.Format("^FO{0},{1}", X, Y);
+        }
+
+        public object Clone()
+        {
+            return new LabelPosition(X, Y);
         }
     }
 }

--- a/src/FluentZpl/ZPL/LabelTextGenerator.cs
+++ b/src/FluentZpl/ZPL/LabelTextGenerator.cs
@@ -7,10 +7,54 @@ namespace ZplLabels.ZPL
         private FontDefinition _font;
         private bool _underline;
 
-
+        /// <summary>
+        /// Set Textposition in Pixel
+        /// </summary>
+        /// <param name="fromLeft"></param>
+        /// <param name="fromTop"></param>
+        /// <returns></returns>
         public LabelTextGenerator At(int fromLeft, int fromTop)
         {
             _position = new LabelPosition(fromLeft, fromTop);
+            return this;
+        }
+
+        /// <summary>
+        /// Set Textposition in milimeter
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="fromLeft"></param>
+        /// <param name="fromTop"></param>
+        /// <returns></returns>
+        public LabelTextGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double fromLeft, double fromTop)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(fromLeft), dpiHelper.mmToPx(fromTop));
+            return this;
+        }
+
+        /// <summary>
+        /// Set Textposition in Pixel
+        /// </summary>
+        /// <param name="fromLeft"></param>
+        /// <param name="fromTop"></param>
+        /// <returns></returns>
+        public LabelTextGenerator At(int fromLeft, int fromTop, LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(fromLeft, fromTop, alignment);
+            return this;
+        }
+
+        /// <summary>
+        /// Set Textposition in milimeter
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="fromLeft"></param>
+        /// <param name="fromTop"></param>
+        /// <returns></returns>
+        public LabelTextGenerator At(ZplLabels.Utilities.DPIHelper dpiHelper, double fromLeft, double fromTop,
+            LabelPosition.LabelAlignemnet alignment)
+        {
+            _position = new LabelPosition(dpiHelper.mmToPx(fromLeft), dpiHelper.mmToPx(fromTop), alignment);
             return this;
         }
 
@@ -22,14 +66,14 @@ namespace ZplLabels.ZPL
 
         public LabelTextGenerator Centered(int width)
         {
-            _block = new FieldBlock(width,1,FieldJustification.Center);
+            _block = new FieldBlock(width, 1, FieldJustification.Center);
             return this;
         }
 
         public LabelTextGenerator SetFont(string type, FieldOrientation orientation, int size)
         {
             _font = new FontDefinition(type, size);
-            _font.SetOrientation(orientation); 
+            _font.SetOrientation(orientation);
             return this;
         }
 
@@ -38,11 +82,12 @@ namespace ZplLabels.ZPL
             _underline = true;
             return this;
         }
+
         public override string ToString()
         {
             if (_position == null) throw new ApplicationException("Field position must be set for text generator");
             if (_data == null) throw new ApplicationException("Field data must be set for text generator");
-              
+
             return _position + getFont() + getBlock() + _script + _data + getUnderline();
         }
 

--- a/src/FluentZpl/ZPL/PrintMode.cs
+++ b/src/FluentZpl/ZPL/PrintMode.cs
@@ -1,0 +1,7 @@
+﻿namespace ZplLabels.ZPL
+{
+    public enum PrintMode
+    {
+        tearOff, cut, peelOff
+    }
+}

--- a/src/FluentZpl/ZPL/ZPLFonts.cs
+++ b/src/FluentZpl/ZPL/ZPLFonts.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ZplLabels.ZPL
+{
+    public class ZplFonts
+    {
+        public static string A = "A";
+        public static string B = "B";
+        public static string D = "D";
+        public static string E = "E";
+        public static string F = "F";
+        public static string G = "G";
+        public static string H = "H";
+        public static string ZERO = "0";
+        public static string P = "P";
+        public static string Q = "Q";
+        public static string R = "R";
+        public static string S = "S";
+        public static string T = "T";
+        public static string U = "U";
+        public static string V = "V";
+        public static string OCR_A = "H";
+        public static string OCR_B = "E";
+        public static string SCALABLE = "0";
+    }
+}

--- a/src/FluentZpl/ZPL/ZplLabel.cs
+++ b/src/FluentZpl/ZPL/ZplLabel.cs
@@ -1,4 +1,6 @@
-﻿namespace ZplLabels.ZPL
+﻿using System;
+
+namespace ZplLabels.ZPL
 {
     public class ZplLabel
     {
@@ -6,24 +8,41 @@
         private string _script;
         private int _homeX;
         private int _homeY;
+        private int _offsetX = 0;
+        private int _offsetY = 0;
+        private int _customCutOffset;
+        private string _customZPL = "";
+        private double? _darkness = null;
+        private int _length = 0;
+        private PrintMode _mode = PrintMode.tearOff;
 
-        public ZplLabel ()
-        { 
+        public ZplLabel()
+        {
         }
 
-        public ZplLabel Load(params IFieldGenerator [] generators)
-        { 
-            foreach(IFieldGenerator gen in generators)
+        /// <summary>
+        /// Load ZPl Label Data
+        /// </summary>
+        /// <param name="generators"></param>
+        /// <returns></returns>
+        public ZplLabel Load(params IFieldGenerator[] generators)
+        {
+            foreach (IFieldGenerator gen in generators)
             {
                 _script += gen.ToString();
 
-            } 
+            }
             return this;
         }
 
+        /// <summary>
+        /// returns ZPL Code
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
-            return getHeader() + getHome() + _script + getFooter();
+            return getHeader() + getLength() + getDarkness() + getLabelOffset() + getHome() +
+                _customZPL + _script + getFooter();
         }
 
         private string getHome()
@@ -31,21 +50,175 @@
             return string.Format("^LH{0},{1}\r\n", _homeX, _homeY);
         }
 
+        /// <summary>
+        /// Sets Homeposition of Label in Pixel
+        /// </summary>
+        /// <param name="fromLeft"></param>
+        /// <param name="fromTop"></param>
+        /// <returns></returns>
         public ZplLabel At(int fromLeft, int fromTop)
         {
             _homeX = fromLeft;
             _homeY = fromTop;
             return this;
         }
+        /// <summary>
+        /// Sets Homeposition of Label in mm
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="fromLeft"></param>
+        /// <param name="fromTop"></param>
+        /// <returns></returns>
+        public ZplLabel At(ZplLabels.Utilities.DPIHelper dpiHelper, double fromLeft, double fromTop)
+        {
+            ;
+            _homeX = dpiHelper.mmToPx(fromLeft);
+            _homeY = dpiHelper.mmToPx(fromTop);
+            return this;
+        }
+
+        /// <summary>
+        /// Cut Offset in Pixel
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        public ZplLabel CutOffset(int offset)
+        {
+            _customCutOffset = offset;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets Label Offset
+        /// </summary>
+        /// <param name="xOffset">x Offset in dots</param>
+        /// <param name="yOffset">y Offset in dot rows</param>
+        /// <returns></returns>
+        public ZplLabel LabelOffset(int xOffset, int yOffset)
+        {
+            _offsetX = xOffset;
+            _offsetY = yOffset;
+            return this;
+        }
+
+        public ZplLabel Length(int length)
+        {
+            _length = length;
+            return this;
+        }
+
+        public ZplLabel Length(ZplLabels.Utilities.DPIHelper dpiHelper, double length)
+        {
+            _length = dpiHelper.mmToPx(length);
+            return this;
+        }
+
+        /// <summary>
+        /// Cut Offset in milimeter
+        /// </summary>
+        /// <param name="dpiHelper"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        public ZplLabel CutOffset(ZplLabels.Utilities.DPIHelper dpiHelper, double offset)
+        {
+            _customCutOffset = dpiHelper.mmToPx(offset);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets Mode of the Printer
+        /// Tear Off
+        /// Peel Off
+        /// Cut
+        /// </summary>
+        /// <param name="mode"></param>
+        /// <returns></returns>
+        public ZplLabel Mode(PrintMode mode)
+        {
+            _mode = mode;
+            return this;
+        }
+
+
+        public ZplLabel Darkness(double darkness)
+        {
+            if (darkness > 30)
+            {
+                darkness = 30;
+            }
+            else if (darkness < 0)
+            {
+                darkness = 0;
+            }
+            _darkness = darkness;
+            return this;
+        }
+
+        /// <summary>
+        /// Insert Custom ZPL Code inside Label
+        /// </summary>
+        /// <param name="customZPL"></param>
+        /// <returns></returns>
+        public ZplLabel customZPLCommand(string customZPL)
+        {
+            _customZPL = customZPL;
+            return this;
+        }
+
         private string getFooter()
         {
-            return @"^XZ
-";
+            return @"^XZ\r\n";
         }
 
         private string getHeader()
         {
-            return "^XA\r\n";
+            var mode = "";
+            switch (_mode)
+            {
+                case PrintMode.peelOff:
+                    mode = "^MMP,N";
+                    break;
+                case PrintMode.cut:
+                    mode = "^MMC,N";
+                    break;
+                case PrintMode.tearOff:
+                    mode = "^MMT,N";
+                    break;
+            }
+
+            return "^XA" + mode + "~TA" + _customCutOffset.ToString("000") + "\r\n";
+        }
+
+        private string getDarkness()
+        {
+            if (_darkness == null)
+            {
+                return "";
+            }
+
+            return "~SD" + Math.Round((double)_darkness, 1).ToString("00.0");
+        }
+
+        private string getLabelOffset()
+        {
+            if (_offsetY > 120)
+            {
+                _offsetY = 120;
+            }
+            else if (_offsetY < -120)
+            {
+                _offsetY = -120;
+            }
+            return "^LT" + _offsetY + "^LS" + _offsetX;
+        }
+
+        private string getLength()
+        {
+            if (_length < 1 || _length > 32000)
+            {
+                return "";
+            }
+            return "^LL" + _length.ToString();
         }
     }
 }

--- a/src/FluentZpl/ZplLabels.csproj
+++ b/src/FluentZpl/ZplLabels.csproj
@@ -65,6 +65,7 @@
     <Compile Include="IZebraPrinterRepository.cs" />
     <Compile Include="PrinterConnection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\DPIHelper.cs" />
     <Compile Include="ZebraPrinter.cs" />
     <Compile Include="ZebraPrinterRepository.cs" />
     <Compile Include="ZPL\BarcodeType.cs" />

--- a/src/FluentZpl/ZplLabels.csproj
+++ b/src/FluentZpl/ZplLabels.csproj
@@ -83,6 +83,8 @@
     <Compile Include="ZPL\LabelBarcodeGenerator.cs" />
     <Compile Include="ZPL\LabelPosition.cs" />
     <Compile Include="ZPL\LabelTextGenerator.cs" />
+    <Compile Include="ZPL\PrintMode.cs" />
+    <Compile Include="ZPL\ZPLFonts.cs" />
     <Compile Include="ZPL\ZplLabel.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ZebraTests/TestLabelOutput.cs
+++ b/src/ZebraTests/TestLabelOutput.cs
@@ -11,11 +11,6 @@ namespace ZebraTests
     public class TestLabelOutput
     {
         private ZplLabel _label;
-        [TestFixtureSetUp]
-        public void SetUpForAllTests()
-        {
-
-        }
         [SetUp]
         public void SetUpForEachTest()
         {
@@ -44,12 +39,6 @@ namespace ZebraTests
 
         [TearDown]
         public void TearDownForEachTest()
-        {
-
-        }
-
-        [TestFixtureTearDown]
-        public void TearDownAfterAllTests()
         {
 
         }

--- a/src/ZebraTests/ZebraTests.csproj
+++ b/src/ZebraTests/ZebraTests.csproj
@@ -34,8 +34,9 @@
     <Reference Include="AFPST.Common">
       <HintPath>..\..\dist\AFP\AFPST.Common.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\lib\nunit\2.5.2.9222\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.9.0\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,6 +60,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/ZebraTests/packages.config
+++ b/src/ZebraTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.9.0" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
- Replace öäü characters with ZPL Escape sequences
- convert milimeters to pixel using DPI value
- Label positions in milimeters
- Field Positions in milimeters
- Added ^LT Label Top (LabelOffset)
- Added ^LS Label Shift (LabelOffset)
- Added conversion from dots to dotrows (used by ^LT)
- Added Label Darkness ~SD (0 - 30)
- Added Support for some Printermodes ^MM (cut, peel Off, tear Off)

